### PR TITLE
Mac-Shim -- For building Scala Android on Macs

### DIFF
--- a/mac-shim/README.txt
+++ b/mac-shim/README.txt
@@ -1,0 +1,14 @@
+# Scala on Android, for Macs 
+
+There are discrepancies in the variable/path names in the Android ant build files.  This file replicates Linux variable names for the Mac Android Ant build script.  It allows Mac users to build and rund Scala apps using the build-scala.xml file provided by this project.
+
+## To use
+
+1. Include `mac-shim.xml` in your project's root directory
+2. Update `build.xml` in your project root to import the mac-shim.  Import after the Android build script, but before the Scala build script.  See below.
+	````
+	<import file="${sdk.dir}/tools/ant/build.xml" /> 
+	<import file="mac-shim.xml" />
+	<import file="build-scala.xml" />
+	````
+

--- a/mac-shim/mac-shim.xml
+++ b/mac-shim/mac-shim.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="mac-shim">
+	<!-- This file is intended to fix discrepancies between 
+			named variables on the linux and osx distributions
+			of the android-sdk/tools/ant/build.xml file -->
+
+	<echo message="Declaring variables for Mac compatibility..." level="info" taskname="mac_shim" />
+	<condition property="extensible.classpath"
+		value="${tested.project.absolute.dir}/bin/classes"
+		else="." >
+		<isset property="tested.project.absolute.dir" />
+	</condition>
+	<condition property="extensible.libs.classpath"
+		value="${tested.project.absolute.dir}/${jar.libs.dir}"
+		else="${jar.libs.dir}" >
+		<isset property="tested.project.absolute.dir" />
+	</condition>
+	<path id="android.target.classpath"> 
+		<path refid="project.target.class.path" />
+	</path>
+	<path id="project.libraries.jars" >
+		<path refid="project.all.jars.path" />
+	</path>
+</project>


### PR DESCRIPTION
'Automated' version of fix mentioned in #2.  Fixes ant build issues for Macs.

Tested on the Accelerometer, HelloActivity, and NotePad with Android SDK 20, Ant 1.8.2, Scala 2.9.2
